### PR TITLE
Fixing bug where 'input_player1_analog_dpad_mode = "1"' exists in es …

### DIFF
--- a/es-cec-input.py
+++ b/es-cec-input.py
@@ -118,7 +118,7 @@ def get_key_bindings(ra_cfg):
     keys = []
     with open(ra_cfg, 'r') as fp:
         for line in fp:
-            if 'input_player1_' in line and '#' not in line:
+            if 'input_player1_' in line and '#' not in line and '_analog_dpad_mode' not in line:
                 keys.append(line.split('=')[1][2:-2])
     return keys
 


### PR DESCRIPTION
…config and script interprets value '1' as a key

Addresses this issue: https://github.com/dillbyrne/es-cec-input/issues/9