### PR TITLE
Update README with instructions on how to deal with not configued keyboard input

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,4 @@ Letters ("a" to "z"), left, right, up, down, enter, kp_enter, tab, insert, del, 
 
 # FAQ
 * The script is not working after exiting from kodi. This is due to a setting in kodi. [Solution](https://github.com/dillbyrne/es-cec-input/issues/2#issuecomment-281341050)
+* Using remote is not controlling menu but signal is being received (goes out of screensaver). Happens when keyboard was not configured as a controller. [Solution](https://github.com/dillbyrne/es-cec-input/issues/1#issuecomment-272633575)


### PR DESCRIPTION
This one bugged me a t first. When keyboard was never used, there is no entry in es_input.cfg file. This results in situation where remote's signal is being received (when in screensaver it goes out of it) but nothing happens in menu. Fortunatelly I found solution in closed issues but having that in FAQ section in README would be nice.