### PR TITLE
Several improvements and fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+es-cec.cfg

--- a/es-cec-input.py
+++ b/es-cec-input.py
@@ -114,7 +114,7 @@ def generate_controller_to_uinput_codes_map():
         print 'The %s keys in your retroarch.cfg are unsupported\
                 by this script\n' % ', '.join(map(str, errors))
         print 'Supported keys are:\n'
-        print get_keymap().keys()
+        print keyboard_to_uinput_mappings.keys()
         sys.exit()
 
     return c_to_u

--- a/es-cec.cfg.example
+++ b/es-cec.cfg.example
@@ -1,0 +1,13 @@
+# Example es-cec-input configuration file
+
+# Known left: up, down, left, right, red, green, yellow, blue
+#            select, back, play, pause, rewind, fast forward
+
+# Known right: up, down, left, right, a, b, x, y, l, r, start, select
+
+# Uncomment to apply mapping
+#red = left
+#green = down
+#yellow = up
+#blue = right
+


### PR DESCRIPTION
- Reduce lines read from cec-client
- Faster conflicting process checking
- Some cec keys are not emitted
- Don't break if lines in retroarch are in different order
- Allow remote key repeats (by holding them down)
- Allow configuration of cec mappings via cfg file
