### PR TITLE
Update es-cec-input.py

### DIFF
--- a/es-cec-input.py
+++ b/es-cec-input.py
@@ -192,7 +192,7 @@ def main():
 
         running_processes = subprocess.check_output(['ps', '-A'])
 
-        if running_processes.find('kodi_v7.bin') == -1 and\
+        if running_processes.find('kodi') == -1 and\
                 running_processes.find('retroarch') == -1 and\
                 running_processes.find('reicast') == -1 and\
                 running_processes.find('drastic') == -1:


### PR DESCRIPTION
es-cec-input_kodi_18_fix

Kodi v18 changed the name of the Kodi process.  Thus, es-cec-input did not detect that Kodi was running.  This cause a double click effect when using the directional keys.  By changing the find command to only look for 'kodi', it fixes the problem in Kodi v18 without breaking Kodi v17.  Using a less precise value for the Kodi process name in theory could make it more susceptible to naming collisions, it seems that changing process names for future Kodi versions is a more likely problem.Kodi v18 changed the name of the Kodi process.  Thus, es-cec-input did not detect that Kodi was running.  This cause a double click effect when using the directional keys.  By changing the find command to only look for 'kodi', it fixes the problem in Kodi v18 without breaking Kodi v17.  Using a less precise value for the Kodi process name in theory could make it more susceptible to naming collisions, it seems that changing process names for future Kodi versions is a more likely problem.Kodi v18 changed the name of the Kodi process.  Thus, es-cec-input did not detect that Kodi was running.  This cause a double click effect when using the directional keys.  By changing the find command to only look for 'kodi', it fixes the problem in Kodi v18 without breaking Kodi v17.  Using a less precise value for the Kodi process name in theory could make it more susceptible to naming collisions, it seems that changing process names for future Kodi versions is a more likely problem.